### PR TITLE
fix: isParticipating 값 가져오기 문제 해결

### DIFF
--- a/src/api/match/match.api.ts
+++ b/src/api/match/match.api.ts
@@ -1,4 +1,5 @@
 import { Response } from "@/types/Response.type";
+import { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { client } from "..";
 
 async function getMatches(sportType: string, date: string, region?: string) {
@@ -58,8 +59,15 @@ async function createMatch(matchDto: any) {
 }
 
 //* match 상세 페이지 조회
-async function getMatchesByMatchId(matchId: string) {
-  const response = await client.get<Response>(`/matches/${matchId}`);
+async function getMatchesByMatchId(
+  matchId: string,
+  accessToken?: RequestCookie
+) {
+  const response = await client.get<Response>(`/matches/${matchId}`, {
+    headers: {
+      Cookie: `${accessToken?.name}=${accessToken?.value}`,
+    },
+  });
 
   const data = response.data;
   if (!data.success) throw new Error(data.message);

--- a/src/app/(providers)/(root)/matches/[matchId]/_components/ApplyButton.tsx
+++ b/src/app/(providers)/(root)/matches/[matchId]/_components/ApplyButton.tsx
@@ -4,7 +4,6 @@ import { useAuth } from "@/contexts/auth.context";
 import { useProfile } from "@/contexts/profile.context";
 import useMutationApplyMatch from "@/hooks/services/matches/useMutationApplyMatch";
 import { useModalStore } from "@/store";
-import isUserParticipating from "@/utils/isUserParticipating";
 import { useState } from "react";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -24,7 +23,7 @@ function ApplyButton({ match, matchId }: ApplyButtonProps) {
   const { mutate: applyMatch } = useMutationApplyMatch(matchId);
 
   const isFull = match.applicants / match.capability >= 1; //* 1. 정원 확인하기
-  const hasApplied = profile ? isUserParticipating(match, profile.id) : false; //* 2. 기신청 여부 확인하기
+  const hasApplied = match.participating;  //* 2. 기신청 여부 확인하기
 
   // ! ============================================================ !
 

--- a/src/app/(providers)/(root)/matches/[matchId]/page.tsx
+++ b/src/app/(providers)/(root)/matches/[matchId]/page.tsx
@@ -2,6 +2,7 @@ import api from "@/api";
 import { MatchDetail } from "@/types/match.response.type";
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
+import { cookies } from "next/headers";
 import AccountContainer from "./_components/AccountContainer";
 import Background from "./_components/Background";
 import GetKakaoMap from "./_components/GetKakaoMap";
@@ -14,8 +15,10 @@ dayjs.locale("ko");
 
 async function MatchDetailPage(props: { params: { matchId: string } }) {
   const matchId = props.params.matchId;
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get("accessToken");
 
-  const match = await api.match.getMatchesByMatchId(matchId);
+  const match = await api.match.getMatchesByMatchId(matchId, accessToken);
   if (!match) return null;
 
   const sportsType = (match as MatchDetail).sportsType.name;


### PR DESCRIPTION
- 매치 상세 페이지는 서버 사이드 페이지이므로 api 호출시 브라우저(클라이언트 사이드)가 아닌, 프론트 노드 서버 자체에서 요청이 날아가게 된다.
- 그래서 백엔드 서버에서 서버 사이드 페이지의 api 호출시에는 브라우저 쿠키를 읽지 못하는 상황(undefined)이 발생하게 되었던 것이다.
- 따라서, header에 쿠키 값을 입력해 api를 호출함으로써, user 정보를 활용하는 isParticipating 필드가 제대로 된 값이 들어가도록 하였다.