### PR TITLE
fix: isParticipating 값 가져오기 문제 해결

### DIFF
--- a/src/api/match/match.api.ts
+++ b/src/api/match/match.api.ts
@@ -2,8 +2,16 @@ import { Response } from "@/types/Response.type";
 import { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { client } from "..";
 
-async function getMatches(sportType: string, date: string, region?: string) {
+async function getMatches(
+  sportType: string,
+  date: string,
+  region?: string,
+  accessToken?: RequestCookie
+) {
   const response = await client.get("/matches", {
+    headers: {
+      Cookie: `${accessToken?.name}=${accessToken?.value}`,
+    },
     params: {
       sportType,
       date,

--- a/src/app/(providers)/(root)/(home)/page.tsx
+++ b/src/app/(providers)/(root)/(home)/page.tsx
@@ -4,6 +4,7 @@ import api from "@/api";
 import Page from "@/components/Page";
 import day from "@/utils/day";
 import { regions } from "@/utils/matchTypes";
+import { cookies } from "next/headers";
 import Banner from "./_components/Banner";
 import MatchesContainer from "./_components/MatchesContainer";
 
@@ -20,7 +21,11 @@ async function HomePage(props: {
     region = undefined,
   } = props.searchParams;
 
-  const matches = await api.match.getMatches(sportType, date, region);
+
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get("accessToken");
+  
+  const matches = await api.match.getMatches(sportType, date, region, accessToken);
   // const { tierId } = useProfileStore();
   // console.log(tierId);
   // tierId 타입은 string[]

--- a/src/components/Buttons/AvailabilityButton/AvailabilityButton.tsx
+++ b/src/components/Buttons/AvailabilityButton/AvailabilityButton.tsx
@@ -12,7 +12,7 @@ function AvailabilityButton({
   const conditionClass =
     label === "신청 가능"
       ? "border border-primary-100 text-primary-100"
-      : label === "마감"
+      : label === "마감" || label === "신청 완료"
       ? "bg-[#E7E7E7] text-[#9BA2A8]"
       : "border border-warning text-warning";
 

--- a/src/types/match.response.type.ts
+++ b/src/types/match.response.type.ts
@@ -15,6 +15,7 @@ export type Match = {
   matchDay: string;
   createdAt: string;
   updatedAt: string | null;
+  participating: boolean;
   participants: [
     {
       id: string;
@@ -41,6 +42,7 @@ export type MatchDetail = {
   matchDay: Date;
   createdAt: Date;
   updatedAt: Date | null;
+  participating: boolean;
   participants: [
     {
       id: string;

--- a/src/utils/getMatchAvailableInfo.ts
+++ b/src/utils/getMatchAvailableInfo.ts
@@ -1,10 +1,16 @@
 import { Match, MatchDetail } from "@/types/match.response.type";
 
 export default function getMatchAvailableInfo(match: Match | MatchDetail) {
-  const { applicants, capability } = match;
+  const { applicants, capability, participating } = match;
 
   const ratio = applicants / capability;
-  const label = ratio < 0.8 ? "신청 가능" : ratio === 1 ? "마감" : "마감 임박";
+  const label = participating
+    ? "신청 완료"
+    : ratio < 0.8
+    ? "신청 가능"
+    : ratio === 1
+    ? "마감"
+    : "마감 임박";
   const imagePath =
     ratio < 0.8
       ? "/assets/main_page/event_available.svg"


### PR DESCRIPTION
- 루트 페이지는 서버 사이드 페이지이므로 api 호출시 브라우저(클라이언트 사이드)가 아닌, 프론트 노드 서버 자체에서 요청이 날아가게 된다.
- 그래서 백엔드 서버에서 서버 사이드 페이지의 api 호출시에는 브라우저 쿠키를 읽지 못하는 상황(undefined)이 발생하게 되었던 것이다.
- 따라서, header에 쿠키 값을 입력해 api를 호출함으로써, user 정보를 활용하는 isParticipating 필드가 제대로 된 값이 들어가도록 하였다.